### PR TITLE
AUTOSCALE-61: UPSTREAM: <carry>: Reduce replicas in scheduling e2e test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/karpenter
 
-go 1.24.0
+go 1.23.6
 
 require (
 	github.com/Pallinder/go-randomdata v1.2.0

--- a/test/suites/perf/scheduling_test.go
+++ b/test/suites/perf/scheduling_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 var _ = Describe("Performance", func() {
-	var replicas = 100
+	var replicas = 6
 
 	Context("Provisioning", func() {
 		It("should do simple provisioning", func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Related: https://issues.redhat.com/browse/AUTOSCALE-166
We need to get rid of this patch once [AUTOSCALE-166](https://issues.redhat.com//browse/AUTOSCALE-166) is resolved.

**Description**
Reduces the scheduling test replicas from 100 to 6. This is a temporary patch to reduce the workload provisioned for the basic core karpenter tests. This PR also downgrades go version from 1.24 to 1.23.6. This needs to happen because the [.ci-operator.yaml](https://github.com/openshift/hypershift/blob/main/.ci-operator.yaml) file in hypershift is still at 1.23 so the ci jobs fail when running 1.24 tests. This has already been tested to work on my fork, and the hypershift release job PR is here: https://github.com/openshift/release/pull/62456. And here's the [test run results](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/62456/rehearse-62456-pull-ci-openshift-hypershift-main-e2e-aws-karpenter-core/1901156790049968128/artifacts/e2e-aws-karpenter-core/e2e-aws-karpenter-core/build-log.txt).

Its changed to 6 because thats the smallest number we can use in order to make all the math work here: https://github.com/openshift/kubernetes-sigs-karpenter/blob/c0e7299834ad615263172c7593049e64ea521cf1/test/suites/perf/scheduling_test.go#L96-L102
Otherwise the test fails.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
