### PR TITLE
AUTOSCALE-257: add OpenShift specific files

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,11 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
 
 approvers:
-  - sig-autoscaling-leads
-  - karpenter-maintainers
-
+  - karpenter-approvers
 reviewers:
   - karpenter-reviewers
+
+# TODO(maxcao13) add component metadata when we know what it will be
+# component:
+# subcomponent:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,18 +1,17 @@
-# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
 
 aliases:
-  sig-autoscaling-leads:
-    - mwielgus
-    - maciekpytel
-    - gjtempleton
-  karpenter-maintainers:
-    - ellistarn
-    - jonathan-innis
-    - tzneal
-    - bwagner5
-    - njtran
+  karpenter-approvers:
+  - elmiko
+  - enxebre
+  - jkyros
+  - joelsmith
+  - maxcao13
+  - muraee
   karpenter-reviewers:
-    - jackfrancis
-    - tallaxes
-    - engedaam
-    - jmdeal
+  - elmiko
+  - enxebre
+  - jkyros
+  - joelsmith
+  - maxcao13
+  - muraee


### PR DESCRIPTION
Changes OWNERS and OWNER_ALIASES to point to openshift people, and adds `.ci-operator.yaml` file for prow ci-operator config.